### PR TITLE
Tests for block subscription process

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nuklai/nuklai-sdk",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "A JavaScript SDK for interacting with the Nuklai blockchain, providing modular services for HyperVM and NuklaiVM.",
   "main": "dist/index.cjs.js",
   "module": "dist/index.esm.js",

--- a/src/sdk.ts
+++ b/src/sdk.ts
@@ -4,6 +4,7 @@ import {
   VM_NAME,
   VM_RPC_PREFIX,
 } from "./endpoints";
+import { Block } from "hypersdk-client/dist/apiTransformers";
 import { NuklaiVMClient } from "./client";
 
 export class NuklaiSDK {
@@ -16,8 +17,12 @@ export class NuklaiSDK {
     this.client = new NuklaiVMClient(baseApiUrl, VM_NAME, VM_RPC_PREFIX);
   }
 
-  listenToBlocks(callback: (block: any) => void) {
-    return this.client.listenToBlocks((block: any) => callback(block));
+  public async listenToBlocks(
+    callback: (block: Block) => void,
+    includeEmpty?: boolean,
+    pollingRateMs?: number
+  ): Promise<() => void> {
+    return this.client.listenToBlocks(callback, includeEmpty, pollingRateMs);
   }
 }
 


### PR DESCRIPTION
```bash
console.log
      Successfully fetched ABI from server

      at NuklaiVMClient.fetchAbiFromServer (src/client.ts:485:17)

    console.log
      Received block: { height: 22203, timestamp: 1731657920611, txCount: 0 }

      at tests/actions.test.ts:526:21
          at Set.forEach (<anonymous>)

    console.log
      Received block: { height: 22204, timestamp: 1731657920864, txCount: 1 }

      at tests/actions.test.ts:526:21
          at Set.forEach (<anonymous>)

    console.log
      Successfully subscribed to block

      at Object.<anonymous> (tests/actions.test.ts:543:17)

    console.log
      Successfully verified transaction in block: { blockHeight: 22206, txCount: 1 }

      at Object.<anonymous> (tests/actions.test.ts:572:17)

    console.log
      Successfully unsubscribe from block

      at Object.<anonymous> (tests/actions.test.ts:593:17)
```      